### PR TITLE
[Feat] 채팅방 생성 API 연동

### DIFF
--- a/src/apis/chatApi.js
+++ b/src/apis/chatApi.js
@@ -1,0 +1,27 @@
+import { defaultInstance, multiInstance } from './utils/instance';
+
+const CHAT_PATH = '/chat-rooms';
+
+// 첫 대화 시작 및 채팅방 생성 (POST)
+export const createChatRoom = async (initialPrompt, files = []) => {
+  // 1. 파일이 있는 경우: multiInstance
+  if (files.length > 0) {
+    const formData = new FormData();
+    formData.append('initialPrompt', initialPrompt);
+
+    files.forEach((fileObj) => {
+      console.log('Sending file:', fileObj.file);
+      formData.append('files', fileObj.file);
+    });
+
+    const response = await multiInstance.post(CHAT_PATH, formData);
+    return response.data;
+  }
+
+  // 2. 파일이 없는 경우: defaultInstance
+  const response = await defaultInstance.post(CHAT_PATH, {
+    initialPrompt,
+  });
+
+  return response.data;
+};

--- a/src/components/FilePreview.jsx
+++ b/src/components/FilePreview.jsx
@@ -1,0 +1,40 @@
+import IconButton from './iconButton/IconButton';
+import { CancelIcon } from './iconButton/Icons';
+
+const FilePreview = ({ files, onRemove }) => {
+  if (files.length === 0) return null;
+
+  return (
+    <div className="flex items-center gap-15 mb-12 overflow-x-auto">
+      {files.map((file) => (
+        <div key={file.id} className="relative w-65 h-65 shrink-0">
+          <div className="w-full h-full bg-gray-150 rounded-6 overflow-hidden flex-row-center">
+            {file.preview ? (
+              // 이미지 미리보기
+              <img src={file.preview} alt="preview" className="w-full h-full object-cover" />
+            ) : (
+              // 문서(PDF 등) 표시
+              <div className="flex-col-center">
+                <span className="text-12 font-bold text-secondary-400 uppercase">
+                  {file.name.split('.').pop()}
+                </span>
+              </div>
+            )}
+          </div>
+
+          {/* 삭제 버튼 */}
+          <div className="absolute top-2 right-2 z-2">
+            <IconButton
+              Icon={CancelIcon}
+              theme="note"
+              onClick={() => onRemove(file.id)}
+              className="w-25 h-25"
+            />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default FilePreview;

--- a/src/components/MainInput.jsx
+++ b/src/components/MainInput.jsx
@@ -4,7 +4,7 @@ import { LinkIcon, SendIcon } from './iconButton/Icons';
 import IconButton from './iconButton/IconButton';
 import FilePreview from './FilePreview';
 
-const MainInput = () => {
+const MainInput = ({ onSend }) => {
   const [text, setText] = useState('');
   const [isMultiLine, setIsMultiLine] = useState(false); // 높이 상태
   const [files, setFiles] = useState([]); // 첨부 파일
@@ -13,6 +13,26 @@ const MainInput = () => {
   const fileInputRef = useRef(null);
   const LINE_HEIGHT = 36;
   const MAX_HEIGHT = LINE_HEIGHT * 2; // 2줄까지 늘어남
+
+  // 메세지 전송 핸들러
+  const handleSend = async () => {
+    if (!text.trim()) return;
+
+    if (onSend) {
+      await onSend(text, files);
+
+      setText('');
+      setFiles([]);
+    }
+  };
+
+  // 엔터 키 핸들러
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  };
 
   // 파일 선택 핸들러
   const handleFileChange = (e) => {
@@ -88,6 +108,7 @@ const MainInput = () => {
           rows={1}
           value={text}
           onChange={(e) => setText(e.target.value)}
+          onKeyDown={handleKeyDown}
           placeholder="새로운 30초 광고 영상을 기획하고 싶은데?"
           className={cn(
             'flex-1 bg-transparent outline-none resize-none font-medium text-secondary-500 placeholder:text-gray-400',
@@ -107,7 +128,7 @@ const MainInput = () => {
             accept=".png,.jpg,.jpeg,.pdf"
           />
           <IconButton Icon={LinkIcon} theme="basic" onClick={() => fileInputRef.current?.click()} />
-          <IconButton Icon={SendIcon} theme="basic" />
+          <IconButton Icon={SendIcon} theme="basic" onClick={handleSend} />
         </div>
       </div>
     </div>

--- a/src/components/MainInput.jsx
+++ b/src/components/MainInput.jsx
@@ -2,21 +2,65 @@ import { useState, useRef, useEffect } from 'react';
 import { cn } from '../lib/utils';
 import { LinkIcon, SendIcon } from './iconButton/Icons';
 import IconButton from './iconButton/IconButton';
+import FilePreview from './FilePreview';
 
-const MainInput = ({ isChat = false }) => {
+const MainInput = () => {
   const [text, setText] = useState('');
   const [isMultiLine, setIsMultiLine] = useState(false); // 높이 상태
-  const textareaRef = useRef(null);
+  const [files, setFiles] = useState([]); // 첨부 파일
 
+  const textareaRef = useRef(null);
+  const fileInputRef = useRef(null);
   const LINE_HEIGHT = 36;
   const MAX_HEIGHT = LINE_HEIGHT * 2; // 2줄까지 늘어남
 
-  useEffect(() => {
-    if (isChat && textareaRef.current) {
-      textareaRef.current.focus();
+  // 파일 선택 핸들러
+  const handleFileChange = (e) => {
+    const selectedFiles = Array.from(e.target.files);
+
+    // 허용할 확장자 목록
+    const ALLOWED_EXTENSIONS = ['png', 'jpg', 'jpeg', 'pdf'];
+
+    // 확장자 검증
+    const isAllAllowed = selectedFiles.every((file) => {
+      const extension = file.name.split('.').pop().toLowerCase();
+      return ALLOWED_EXTENSIONS.includes(extension);
+    });
+
+    if (!isAllAllowed) {
+      alert('png, jpg, jpeg, pdf 파일만 첨부할 수 있습니다.');
+      e.target.value = '';
+      return;
     }
 
-    if (!isChat && textareaRef.current) {
+    // 개수 제한 체크
+    if (files.length + selectedFiles.length > 5) {
+      alert('파일은 최대 5개까지 첨부할 수 있습니다.');
+      return;
+    }
+
+    const newFiles = selectedFiles.map((file) => ({
+      id: Date.now() + Math.random(),
+      file,
+      preview: file.type.startsWith('image/') ? URL.createObjectURL(file) : null,
+      name: file.name,
+    }));
+
+    setFiles((prev) => [...prev, ...newFiles]);
+    e.target.value = '';
+  };
+
+  // 파일 삭제 핸들러
+  const removeFile = (id) => {
+    setFiles((prev) => {
+      const target = prev.find((f) => f.id === id);
+      if (target?.preview) URL.revokeObjectURL(target.preview);
+      return prev.filter((f) => f.id !== id);
+    });
+  };
+
+  useEffect(() => {
+    if (textareaRef.current) {
       textareaRef.current.style.height = 'auto';
       const scrollHeight = textareaRef.current.scrollHeight;
 
@@ -25,34 +69,46 @@ const MainInput = ({ isChat = false }) => {
 
       setIsMultiLine(scrollHeight > 45);
     }
-  }, [text, isChat, MAX_HEIGHT]);
+  }, [text, MAX_HEIGHT]);
 
   return (
     <div
       className={cn(
-        'flex-row-center w-[90vw] lg:w-[73.8vw] max-w-[1064px] bg-white transition-all duration-300 shrink-0 items-center shadow-sub',
-        'px-[3%]',
-        isChat ? 'h-94 rounded-100' : 'min-h-94 h-auto py-28',
-        !isChat && (isMultiLine ? 'rounded-20' : 'rounded-100'),
+        'flex flex-col w-[90vw] lg:w-[73.8vw] max-w-1064 bg-white transition-all duration-300 shrink-0 shadow-sub px-[3%]',
+        'min-h-94 h-auto py-28',
+        isMultiLine || files.length > 0 ? 'rounded-20' : 'rounded-100',
       )}
     >
-      <textarea
-        ref={textareaRef}
-        rows={1}
-        value={text}
-        onChange={(e) => setText(e.target.value)}
-        placeholder={isChat ? '' : '새로운 30초 광고 영상을 기획하고 싶은데?'}
-        className={cn(
-          'flex-1 bg-transparent outline-none resize-none font-medium text-secondary-500 placeholder:text-gray-400',
-          'text-24 leading-36 self-center mr-20 lg:mr-50',
-          isChat ? 'h-36 overflow-hidden' : 'min-h-36 max-h-72 overflow-y-auto custom-scrollbar',
-        )}
-      />
+      {/* 파일 미리보기 */}
+      <FilePreview files={files} onRemove={removeFile} />
 
-      {/* 링크, 전송 버튼 */}
-      <div className="flex-row-center justify-between w-90 lg:w-108 h-35 shrink-0">
-        <IconButton Icon={LinkIcon} theme="basic" />
-        <IconButton Icon={SendIcon} theme="basic" />
+      <div className="flex items-center w-full">
+        <textarea
+          ref={textareaRef}
+          rows={1}
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder="새로운 30초 광고 영상을 기획하고 싶은데?"
+          className={cn(
+            'flex-1 bg-transparent outline-none resize-none font-medium text-secondary-500 placeholder:text-gray-400',
+            'text-24 leading-36 self-center mr-20 lg:mr-50',
+            'min-h-36 max-h-72 overflow-y-auto',
+          )}
+        />
+
+        {/* 링크, 전송 버튼 */}
+        <div className="flex-row-center justify-between w-90 lg:w-108 h-35 shrink-0">
+          <input
+            type="file"
+            ref={fileInputRef}
+            onChange={handleFileChange}
+            className="hidden"
+            multiple
+            accept=".png,.jpg,.jpeg,.pdf"
+          />
+          <IconButton Icon={LinkIcon} theme="basic" onClick={() => fileInputRef.current?.click()} />
+          <IconButton Icon={SendIcon} theme="basic" />
+        </div>
       </div>
     </div>
   );

--- a/src/components/MainInput.jsx
+++ b/src/components/MainInput.jsx
@@ -3,6 +3,7 @@ import { cn } from '../lib/utils';
 import { LinkIcon, SendIcon } from './iconButton/Icons';
 import IconButton from './iconButton/IconButton';
 import FilePreview from './FilePreview';
+import { validateFiles, formatFileSelection, revokeFiles } from '../utils/file';
 
 const MainInput = ({ onSend }) => {
   const [text, setText] = useState('');
@@ -14,6 +15,10 @@ const MainInput = ({ onSend }) => {
   const LINE_HEIGHT = 36;
   const MAX_HEIGHT = LINE_HEIGHT * 2; // 2줄까지 늘어남
 
+  useEffect(() => {
+    return () => revokeFiles(files);
+  }, []);
+
   // 메세지 전송 핸들러
   const handleSend = async () => {
     if (!text.trim()) return;
@@ -21,6 +26,7 @@ const MainInput = ({ onSend }) => {
     if (onSend) {
       await onSend(text, files);
 
+      revokeFiles(files);
       setText('');
       setFiles([]);
     }
@@ -38,33 +44,17 @@ const MainInput = ({ onSend }) => {
   const handleFileChange = (e) => {
     const selectedFiles = Array.from(e.target.files);
 
-    // 허용할 확장자 목록
-    const ALLOWED_EXTENSIONS = ['png', 'jpg', 'jpeg', 'pdf'];
+    // 검증
+    const { isValid, msg } = validateFiles(selectedFiles, files.length);
 
-    // 확장자 검증
-    const isAllAllowed = selectedFiles.every((file) => {
-      const extension = file.name.split('.').pop().toLowerCase();
-      return ALLOWED_EXTENSIONS.includes(extension);
-    });
-
-    if (!isAllAllowed) {
-      alert('png, jpg, jpeg, pdf 파일만 첨부할 수 있습니다.');
+    if (!isValid) {
+      alert(msg);
       e.target.value = '';
       return;
     }
 
-    // 개수 제한 체크
-    if (files.length + selectedFiles.length > 5) {
-      alert('파일은 최대 5개까지 첨부할 수 있습니다.');
-      return;
-    }
-
-    const newFiles = selectedFiles.map((file) => ({
-      id: Date.now() + Math.random(),
-      file,
-      preview: file.type.startsWith('image/') ? URL.createObjectURL(file) : null,
-      name: file.name,
-    }));
+    // 데이터 포맷팅
+    const newFiles = formatFileSelection(selectedFiles);
 
     setFiles((prev) => [...prev, ...newFiles]);
     e.target.value = '';

--- a/src/components/iconButton/IconButton.jsx
+++ b/src/components/iconButton/IconButton.jsx
@@ -11,15 +11,17 @@ const THEMES = {
 };
 
 const IconButton = ({ Icon, onClick, theme = 'basic', className = '' }) => {
+  const hasSize = className.includes('w-') || className.includes('h-');
+
   return (
     <button
       onClick={onClick}
       className={`
-        w-35 h-35 shrink-0 flex-row-center rounded-100 transition-all outline-none border-none active:scale-95 
+        ${hasSize ? '' : 'w-35 h-35'} shrink-0 flex-row-center rounded-100 transition-all outline-none border-none active:scale-95 
         ${THEMES[theme].button} ${className}
       `}
     >
-      {Icon && <Icon className={`w-23 h-23 ${THEMES[theme].icon} transition-colors`} />}
+      {Icon && <Icon className={`w-[65%] h-[65%] ${THEMES[theme].icon} transition-colors`} />}
     </button>
   );
 };

--- a/src/hooks/useChat.js
+++ b/src/hooks/useChat.js
@@ -1,0 +1,85 @@
+import { useState, useCallback, useReducer } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { createChatRoom } from '../apis/chatApi';
+
+// 메시지 상태 변화 로직 Reducer
+const messageReducer = (state, action) => {
+  switch (action.type) {
+    case 'ADD_MESSAGE':
+      return [
+        ...state,
+        {
+          type: action.payload.type,
+          content: action.payload.content,
+          files: action.payload.files || [],
+        },
+      ];
+    case 'SET_MESSAGES':
+      return action.payload;
+    case 'CLEAR_MESSAGES':
+      return [];
+    default:
+      return state;
+  }
+};
+
+export const useChat = () => {
+  const [messages, dispatch] = useReducer(messageReducer, []);
+  const [, /*chatRoomId*/ setChatRoomId] = useState(null);
+  const [isThinking, setIsThinking] = useState(false);
+
+  // 채팅방 초기 생성
+  const createRoomMutation = useMutation({
+    mutationFn: ({ prompt, files }) => createChatRoom(prompt, files),
+    onSuccess: (response) => {
+      const { data } = response;
+      setChatRoomId(data.chatRoomId);
+
+      const aiAnswer = data.firstMessage.answer;
+      dispatch({
+        type: 'ADD_MESSAGE',
+        payload: { type: 'ai', content: aiAnswer },
+      });
+      setIsThinking(false);
+    },
+    onError: (error) => {
+      console.error('채팅방 생성 실패:', error);
+      setIsThinking(false);
+    },
+  });
+
+  const addMessage = useCallback((type, content, files = []) => {
+    dispatch({
+      type: 'ADD_MESSAGE',
+      payload: { type, content, files },
+    });
+  }, []);
+
+  // 페이지 진입 시 최초 실행 함수
+  const mutateCreateRoom = createRoomMutation.mutate;
+  const startNewChat = useCallback(
+    (prompt, files) => {
+      setIsThinking(true);
+      addMessage('user', prompt, files);
+      mutateCreateRoom({ prompt, files });
+    },
+    [addMessage, mutateCreateRoom],
+  );
+
+  // 메시지 전송 함수
+  const sendNextMessage = useCallback(
+    (text, files) => {
+      setIsThinking(true);
+      addMessage('user', text, files);
+      // 구현 예정
+    },
+    [addMessage],
+  );
+
+  return {
+    messages,
+    isThinking,
+    startNewChat,
+    sendNextMessage,
+  };
+};

--- a/src/pages/brainstormPage/BrainstormPage.jsx
+++ b/src/pages/brainstormPage/BrainstormPage.jsx
@@ -1,77 +1,36 @@
-import { useState, useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
 import MainInput from '../../components/MainInput';
 import ChatBubble from './components/ChatBubble';
 import useThinkingDots from './hooks/useThinkingDots';
-import { createChatRoom } from '../../apis/chatApi';
+import { useChat } from '../../hooks/useChat';
+import { useScrollToBottom } from './hooks/useScrollToBottom';
 
 const BrainstormPage = () => {
   const location = useLocation();
   const { initialPrompt, initialFiles } = location.state || {};
 
-  // 대화 내역 상태 관리
-  const [messages, setMessages] = useState([]);
-  const [isThinking, setIsThinking] = useState(false);
+  const { messages, isThinking, startNewChat, sendNextMessage } = useChat();
   const dots = useThinkingDots(isThinking);
 
-  const isFirstRender = useRef(true); // 초기 API 호출 중복 방지용 플래그
+  // 자동 스크롤 훅 적용
+  const scrollRef = useScrollToBottom(messages);
+  const isFirstRender = useRef(true);
 
   // 초기 데이터 세팅 및 API 호출
   useEffect(() => {
     if (initialPrompt && isFirstRender.current) {
       isFirstRender.current = false;
-
-      setMessages([
-        {
-          type: 'user',
-          content: initialPrompt,
-          files: initialFiles || [],
-        },
-      ]);
-      setIsThinking(true);
-
-      // 채팅방 생성 API 호출
-      const initChat = async () => {
-        try {
-          const response = await createChatRoom(initialPrompt, initialFiles);
-
-          setMessages((prev) => [
-            ...prev,
-            {
-              type: 'ai',
-              content: response.data.firstMessage.answer,
-            },
-          ]);
-        } catch (error) {
-          console.error('초기 대화 생성 실패:', error);
-        } finally {
-          setIsThinking(false);
-        }
-      };
-
-      initChat();
+      startNewChat(initialPrompt, initialFiles);
     }
-  }, [initialPrompt, initialFiles]);
-
-  // 대화 전송 핸들러
-  const handleChatSend = async (text, files) => {
-    const userMsg = { type: 'user', content: text, files: files || [] };
-    setMessages((prev) => [...prev, userMsg]);
-
-    setIsThinking(true);
-
-    try {
-      // 대화 이어가기 API 호출 예정
-    } catch (error) {
-      console.error('대화 전송 실패:', error);
-    } finally {
-      setIsThinking(false);
-    }
-  };
+  }, []);
 
   return (
     <div className="relative flex flex-col w-full h-full bg-primary-0">
-      <div className="flex-1 flex flex-col gap-50 overflow-y-auto px-85 pt-50 pb-200 custom-scrollbar">
+      <div
+        ref={scrollRef}
+        className="flex-1 flex flex-col gap-50 overflow-y-auto px-85 pt-50 pb-200 custom-scrollbar"
+      >
         {messages.map((msg, index) => (
           <ChatBubble key={index} type={msg.type} content={msg.content} files={msg.files} />
         ))}
@@ -83,7 +42,7 @@ const BrainstormPage = () => {
       {/* 입력창 (하단 고정) */}
       <div className="fixed bottom-38 left-0 right-0 flex justify-center z-50 pointer-events-none">
         <div className="pointer-events-auto">
-          <MainInput onSend={handleChatSend} />
+          <MainInput onSend={sendNextMessage} />
         </div>
       </div>
     </div>

--- a/src/pages/brainstormPage/BrainstormPage.jsx
+++ b/src/pages/brainstormPage/BrainstormPage.jsx
@@ -34,7 +34,7 @@ const BrainstormPage = () => {
       {/* 입력창 (하단 고정) */}
       <div className="fixed bottom-38 left-0 right-0 flex justify-center z-50 pointer-events-none">
         <div className="pointer-events-auto">
-          <MainInput isChat={true} />
+          <MainInput />
         </div>
       </div>
     </div>

--- a/src/pages/brainstormPage/BrainstormPage.jsx
+++ b/src/pages/brainstormPage/BrainstormPage.jsx
@@ -1,40 +1,89 @@
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
 import MainInput from '../../components/MainInput';
 import ChatBubble from './components/ChatBubble';
-import ModeSelector from './components/ModeSelector';
-import StepController from './components/StepController';
 import useThinkingDots from './hooks/useThinkingDots';
+import { createChatRoom } from '../../apis/chatApi';
 
 const BrainstormPage = () => {
-  const [isThinking /*setIsThinking*/] = useState(true); // AI 답변 로딩 중
+  const location = useLocation();
+  const { initialPrompt, initialFiles } = location.state || {};
+
+  // 대화 내역 상태 관리
+  const [messages, setMessages] = useState([]);
+  const [isThinking, setIsThinking] = useState(false);
   const dots = useThinkingDots(isThinking);
+
+  const isFirstRender = useRef(true); // 초기 API 호출 중복 방지용 플래그
+
+  // 초기 데이터 세팅 및 API 호출
+  useEffect(() => {
+    if (initialPrompt && isFirstRender.current) {
+      isFirstRender.current = false;
+
+      setMessages([
+        {
+          type: 'user',
+          content: initialPrompt,
+          files: initialFiles || [],
+        },
+      ]);
+      setIsThinking(true);
+
+      // 채팅방 생성 API 호출
+      const initChat = async () => {
+        try {
+          const response = await createChatRoom(initialPrompt, initialFiles);
+
+          setMessages((prev) => [
+            ...prev,
+            {
+              type: 'ai',
+              content: response.data.firstMessage.answer,
+            },
+          ]);
+        } catch (error) {
+          console.error('초기 대화 생성 실패:', error);
+        } finally {
+          setIsThinking(false);
+        }
+      };
+
+      initChat();
+    }
+  }, [initialPrompt, initialFiles]);
+
+  // 대화 전송 핸들러
+  const handleChatSend = async (text, files) => {
+    const userMsg = { type: 'user', content: text, files: files || [] };
+    setMessages((prev) => [...prev, userMsg]);
+
+    setIsThinking(true);
+
+    try {
+      // 대화 이어가기 API 호출 예정
+    } catch (error) {
+      console.error('대화 전송 실패:', error);
+    } finally {
+      setIsThinking(false);
+    }
+  };
 
   return (
     <div className="relative flex flex-col w-full h-full bg-primary-0">
-      <div className="flex-1 flex flex-col gap-50 overflow-y-auto px-85 pt-50 pb-200">
+      <div className="flex-1 flex flex-col gap-50 overflow-y-auto px-85 pt-50 pb-200 custom-scrollbar">
+        {messages.map((msg, index) => (
+          <ChatBubble key={index} type={msg.type} content={msg.content} files={msg.files} />
+        ))}
+
         {/* AI 로딩 말풍선 */}
         {isThinking && <ChatBubble content={`생각 퍼즐 맞추는 중${dots}`} />}
-
-        {/* AI 질문 예시 */}
-        <ChatBubble content={`Q2. 타겟 고객을 한 문장으로 표현한다면?`} />
-
-        {/* 사용자 답변 예시 */}
-        <ChatBubble
-          type="user"
-          content={`나는 화장품 브랜드 콘텐츠 마케터야. 친환경 화장품 캠페인 아이디어 좀 도와줘.\n(상품설명) 내가 첨부한 레퍼런스와 자료를 바탕으로 부탁할게.`}
-        />
-
-        {/* 모드 선택 */}
-        <ModeSelector onSelect={(id) => console.log('선택된 모드:', id)} />
-
-        {/* 모드 시작 여부 선택 */}
-        <StepController modeId="theory" onConfirm={() => console.log('대화 시작!')} />
       </div>
 
       {/* 입력창 (하단 고정) */}
       <div className="fixed bottom-38 left-0 right-0 flex justify-center z-50 pointer-events-none">
         <div className="pointer-events-auto">
-          <MainInput />
+          <MainInput onSend={handleChatSend} />
         </div>
       </div>
     </div>

--- a/src/pages/brainstormPage/components/ChatBubble.jsx
+++ b/src/pages/brainstormPage/components/ChatBubble.jsx
@@ -1,6 +1,6 @@
 import BOT from '@assets/images/bot.svg';
 
-const ChatBubble = ({ type, content, children, className }) => {
+const ChatBubble = ({ type, content, files = [], children, className }) => {
   const isUser = type === 'user';
 
   // 말풍선 배치: AI(왼)/ User(오)
@@ -13,7 +13,33 @@ const ChatBubble = ({ type, content, children, className }) => {
       <div className={`flex ${isUser ? '' : 'flex-row'} max-w-820`}>
         {/* AI 봇 아이콘 */}
         {!isUser && <img src={BOT} alt="bot" className="w-120 h-120 shrink-0 self-start" />}
-        <div className="flex flex-col items-center max-w-700">
+
+        <div className={`flex flex-col ${isUser ? 'items-end' : 'items-center'} max-w-700`}>
+          {/* 첨부한 파일 목록 */}
+          {isUser && files.length > 0 && (
+            <div className="flex gap-20 mb-20 flex-wrap justify-end">
+              {files.map((fileObj, idx) => (
+                <div
+                  key={idx}
+                  className="w-120 h-120 rounded-6 overflow-hidden shadow-sub shrink-0"
+                >
+                  {fileObj.preview ? (
+                    <img
+                      src={fileObj.preview}
+                      alt="upload-preview"
+                      className="w-full h-full object-cover"
+                    />
+                  ) : (
+                    <div className="w-full h-full bg-gray-200 flex-row-center text-12 text-gray-500">
+                      PDF
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* 말풍선 본체 */}
           <div
             className={`shadow-sub rounded-20 px-50 py-29 bg-white text-18 font-medium ${textColorClass}`}
           >

--- a/src/pages/brainstormPage/hooks/useScrollToBottom.js
+++ b/src/pages/brainstormPage/hooks/useScrollToBottom.js
@@ -1,0 +1,17 @@
+import { useEffect, useRef } from 'react';
+
+// 요소의 스크롤을 하단으로 자동 이동시키는 훅
+export const useScrollToBottom = (dependency) => {
+  const scrollRef = useRef(null);
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTo({
+        top: scrollRef.current.scrollHeight,
+        behavior: 'smooth',
+      });
+    }
+  }, [dependency]);
+
+  return scrollRef;
+};

--- a/src/pages/mainPage/MainPage.jsx
+++ b/src/pages/mainPage/MainPage.jsx
@@ -2,6 +2,7 @@ import MainInput from '../../components/MainInput';
 import FEAT1 from '@assets/images/feature_1.webp';
 import FEAT2 from '@assets/images/feature_2.webp';
 import FeatureCard from './components/FeatureCard';
+import useNavigation from '../../hooks/useNavigation';
 
 const features = [
   {
@@ -19,12 +20,24 @@ const features = [
 ];
 
 const MainPage = () => {
+  const { goTo } = useNavigation();
+
+  // 전송 핸들러
+  const handleMainSend = (text, files) => {
+    goTo('/brainstorm', {
+      state: {
+        initialPrompt: text,
+        initialFiles: files,
+      },
+    });
+  };
+
   return (
     <div className="w-full min-h-screen flex-col-center gap-50 bg-primary-0">
       <p className="text-42 font-bold text-secondary-500 text-center mb-14 whitespace-pre-line">{`브레인스토밍 주제를 입력하고,\n작은 아이디어를 확장시켜요.`}</p>
 
       {/* 입력창 */}
-      <MainInput />
+      <MainInput onSend={handleMainSend} />
 
       {/* 사용 가이드 */}
       <div className="peer flex-row-center rounded-8 w-178 h-44 bg-primary-400 text-white text-20 font-medium px-12 py-10 hover:bg-primary-200 duration-150 cursor-default">

--- a/src/utils/file.js
+++ b/src/utils/file.js
@@ -1,0 +1,36 @@
+export const ALLOWED_EXTENSIONS = ['png', 'jpg', 'jpeg', 'pdf'];
+
+// 확장자 및 개수 검증
+export const validateFiles = (selectedFiles, currentFilesCount) => {
+  const isAllAllowed = selectedFiles.every((file) => {
+    const extension = file.name.split('.').pop().toLowerCase();
+    return ALLOWED_EXTENSIONS.includes(extension);
+  });
+
+  if (!isAllAllowed) {
+    return { isValid: false, msg: 'png, jpg, jpeg, pdf 파일만 첨부할 수 있습니다.' };
+  }
+
+  if (currentFilesCount + selectedFiles.length > 5) {
+    return { isValid: false, msg: '파일은 최대 5개까지 첨부할 수 있습니다.' };
+  }
+
+  return { isValid: true };
+};
+
+// 파일 객체 포맷팅 및 프리뷰 생성
+export const formatFileSelection = (selectedFiles) => {
+  return selectedFiles.map((file) => ({
+    id: Date.now() + Math.random(),
+    file,
+    preview: file.type.startsWith('image/') ? URL.createObjectURL(file) : null,
+    name: file.name,
+  }));
+};
+
+// 메모리 해제
+export const revokeFiles = (files) => {
+  files.forEach((f) => {
+    if (f.preview) URL.revokeObjectURL(f.preview);
+  });
+};


### PR DESCRIPTION
## 📝 Work Description
<!-- 작업한 내용을 모두 작성해 주세요. -->
- `MainInput`, `ChatBubble`에 첨부한 파일 UI 추가
- 파일 첨부 기능: jpg, jpeg, png, pdf 최대 5개
- 채팅방 생성 api(POST) 연동 및 브레인스토밍페이지로 이동
- 채팅방 자동 스크롤 기능

## 🚨 Notice
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->
- 경로가 `api/chat-rooms`로 시작하는 api들은 모두 `src/apis/chatApi.js`에 작성하면 됩니다.
- 메세지 상태는 `src/hooks/useChat.js`에서 관리합니다. (그냥 참고)

## #️⃣ Related Issue
<!-- 연관된 이슈를 태그해 주세요. -->
- close #34 
  
## 👀 ScreenShot
<!-- 결과 이미지를 첨부해 주세요. -->
단톡방에 보냄

