### PR TITLE
[Fix] 폴더 active 스타일을 페이지 이동하면 초기화되도록 수정

### DIFF
--- a/src/pages/archiveFolderPage/ArchiveFolderPage.jsx
+++ b/src/pages/archiveFolderPage/ArchiveFolderPage.jsx
@@ -15,6 +15,7 @@ export default function ArchiveFolderPage() {
   const { folderId: folderIdStr } = useParams();
   const folderId = parseInt(folderIdStr, 10);
   const folders = useArchiveStore((state) => state.folders);
+  const setActiveFolderId = useArchiveStore((state) => state.setActiveFolderId);
 
   const chats = useChatStore((state) => state.getChats(folderId));
   const fetchChatsByFolder = useChatStore((state) => state.fetchChatsByFolder);
@@ -31,7 +32,12 @@ export default function ArchiveFolderPage() {
   useEffect(() => {
     clearSelection();
     fetchChatsByFolder(folderId);
-  }, [folderId, clearSelection, fetchChatsByFolder]);
+    setActiveFolderId(folderId);
+
+    return () => {
+      setActiveFolderId(null);
+    };
+  }, [folderId, clearSelection, fetchChatsByFolder, setActiveFolderId]);
 
   // 업로드 완료 시
   const onConfirmUpload = async () => {
@@ -83,7 +89,7 @@ export default function ArchiveFolderPage() {
         <UploadModal
           open={uploadModal.open}
           onClose={() => uploadModal.setOpen(false)}
-          onConfirm={onConfirmUpload} // ✅ 이제 notes 안 받음
+          onConfirm={onConfirmUpload}
           folderId={folderId}
         />
 

--- a/src/pages/archivePage/ArchivePage.jsx
+++ b/src/pages/archivePage/ArchivePage.jsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { cn } from '../../lib/utils';
 import Sidebar from './components/Sidebar';
 import FolderCard from './components/FolderCard';
@@ -12,11 +13,16 @@ import { SortableContext, rectSortingStrategy } from '@dnd-kit/sortable';
 import SortableFolderItem from './components/SortableFolderItem';
 
 const ArchivePage = () => {
-  const { folders, modal, deleteFolder, closeModal } = useArchiveStore();
+  const { folders, modal, deleteFolder, closeModal, setActiveFolderId } = useArchiveStore();
   const { isOpen, variant, data } = modal;
 
   useFoldersQuery(); // 폴더 조회
   const { sensors, handleDragEnd } = useFolderDnd();
+
+  // 다른 페이지에서 돌아왔을 때 active 상태 초기화
+  useEffect(() => {
+    setActiveFolderId(null);
+  }, [setActiveFolderId]);
 
   // 폴더 삭제 처리
   const handleDeleteFolder = async (folderId) => {


### PR DESCRIPTION
## 📝 Work Description
- 폴더 active 스타일을 페이지 이동하면 초기화되도록 수정

## 🚨 Notice
다른 페이지로 이동했다가 다시 돌아오면, 이전에 선택했던 폴더의 active 색상이 그대로 남아있는 현상을 해결했습니다.

## #️⃣ Related Issue
- close #46
  
## 👀 ScreenShot
